### PR TITLE
Add CDK stack for approved model deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# SageMaker Model Deployment CDK Example
+
+This repository contains an example AWS CDK stack that demonstrates how to
+retrieve an approved model from the SageMaker Model Registry and deploy it to a
+SageMaker endpoint on the new unified Studio platform.
+
+The stack performs the following actions:
+
+1. Uses a Lambda function to list the latest approved model package from a model
+   package group.
+2. Deploys the model by creating the SageMaker model, endpoint configuration and
+   endpoint through AWS Step Functions.
+3. Creates a new SageMaker Domain configured for the unified Studio experience.
+
+## Getting Started
+
+Install the Python dependencies:
+
+```bash
+pip install -r cdk/requirements.txt
+```
+
+Synthesize the CloudFormation templates:
+
+```bash
+cdk synth -a cdk/app.py
+```
+
+Deploy the stack (make sure you have configured your AWS credentials):
+
+```bash
+cdk deploy -a cdk/app.py
+```
+
+The model package group name can be provided via CDK context:
+
+```bash
+cdk deploy -a cdk/app.py -c model_package_group_name=MyModelGroup
+```
+
+Optionally specify a region to query the model registry by providing `model_region`:
+
+```bash
+cdk deploy -a cdk/app.py -c model_region=us-west-2
+```

--- a/cdk/app.py
+++ b/cdk/app.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+import aws_cdk as cdk
+from model_deployment_stack import ModelDeploymentStack
+
+app = cdk.App()
+ModelDeploymentStack(app, "ModelDeploymentStack")
+app.synth()

--- a/cdk/lambda/check_model_approved.py
+++ b/cdk/lambda/check_model_approved.py
@@ -1,0 +1,32 @@
+import os
+import boto3
+
+REGION = os.environ.get("SAGEMAKER_REGION")
+sagemaker = (
+    boto3.client("sagemaker", region_name=REGION)
+    if REGION
+    else boto3.client("sagemaker")
+)
+MODEL_PACKAGE_GROUP_NAME = os.environ["MODEL_PACKAGE_GROUP_NAME"]
+
+
+def handler(event, context):
+    response = sagemaker.list_model_packages(
+        ModelPackageGroupName=MODEL_PACKAGE_GROUP_NAME,
+        ModelApprovalStatus="Approved",
+        SortBy="CreationTime",
+        SortOrder="Descending",
+        MaxResults=1,
+    )
+    packages = response.get("ModelPackageSummaryList", [])
+    if not packages:
+        raise Exception("No approved models found")
+
+    model_package_arn = packages[0]["ModelPackageArn"]
+    name_part = model_package_arn.split("/")[-1]
+    return {
+        "ModelPackageArn": model_package_arn,
+        "ModelName": f"{name_part}-model",
+        "EndpointConfigName": f"{name_part}-config",
+        "EndpointName": f"{name_part}-endpoint",
+    }

--- a/cdk/model_deployment_stack.py
+++ b/cdk/model_deployment_stack.py
@@ -1,0 +1,112 @@
+from aws_cdk import (
+    Stack,
+    Duration,
+    aws_lambda as _lambda,
+    aws_iam as iam,
+    aws_stepfunctions as sfn,
+    aws_stepfunctions_tasks as tasks,
+    aws_sagemaker as sagemaker,
+)
+from constructs import Construct
+
+
+class ModelDeploymentStack(Stack):
+    def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
+        super().__init__(scope, construct_id, **kwargs)
+
+        check_model_lambda = _lambda.Function(
+            self,
+            "CheckModelLambda",
+            runtime=_lambda.Runtime.PYTHON_3_9,
+            handler="check_model_approved.handler",
+            code=_lambda.Code.from_asset("lambda"),
+            environment={
+                "MODEL_PACKAGE_GROUP_NAME": self.node.try_get_context(
+                    "model_package_group_name"
+                )
+                or "MyModelGroup",
+                "SAGEMAKER_REGION": self.node.try_get_context("model_region")
+                or Stack.of(self).region,
+            },
+        )
+
+        check_model_lambda.add_to_role_policy(
+            iam.PolicyStatement(
+                actions=["sagemaker:ListModelPackages"], resources=["*"]
+            )
+        )
+
+        check_model_step = tasks.LambdaInvoke(
+            self,
+            "CheckApprovedModel",
+            lambda_function=check_model_lambda,
+            output_path="$.Payload",
+        )
+
+        create_model = tasks.CallAwsService(
+            self,
+            "CreateModel",
+            service="sagemaker",
+            action="createModel",
+            parameters={
+                "ModelName.$": "$.ModelName",
+                "ExecutionRoleArn": check_model_lambda.role.role_arn,
+                "Containers": [{"ModelPackageName.$": "$.ModelPackageArn"}],
+            },
+            iam_resources=["*"],
+        )
+
+        create_config = tasks.CallAwsService(
+            self,
+            "CreateEndpointConfig",
+            service="sagemaker",
+            action="createEndpointConfig",
+            parameters={
+                "EndpointConfigName.$": "$.EndpointConfigName",
+                "ProductionVariants": [
+                    {
+                        "ModelName.$": "$.ModelName",
+                        "InitialInstanceCount": 1,
+                        "InstanceType": "ml.m5.large",
+                        "VariantName": "AllTraffic",
+                    }
+                ],
+            },
+            iam_resources=["*"],
+        )
+
+        create_endpoint = tasks.CallAwsService(
+            self,
+            "CreateEndpoint",
+            service="sagemaker",
+            action="createEndpoint",
+            parameters={
+                "EndpointName.$": "$.EndpointName",
+                "EndpointConfigName.$": "$.EndpointConfigName",
+            },
+            iam_resources=["*"],
+        )
+
+        definition = (
+            check_model_step.next(create_model)
+            .next(create_config)
+            .next(create_endpoint)
+        )
+
+        sfn.StateMachine(
+            self,
+            "ModelDeploymentStateMachine",
+            definition=definition,
+            timeout=Duration.minutes(30),
+        )
+
+        # Example domain for unified Studio
+        sagemaker.CfnDomain(
+            self,
+            "SageMakerDomain",
+            auth_mode="IAM",
+            default_user_settings=sagemaker.CfnDomain.UserSettingsProperty(
+                execution_role=check_model_lambda.role.role_arn
+            ),
+            domain_name="ml-domain",
+        )

--- a/cdk/requirements.txt
+++ b/cdk/requirements.txt
@@ -1,0 +1,3 @@
+aws-cdk-lib>=2.0.0
+constructs>=10.0.0
+boto3


### PR DESCRIPTION
## Summary
- add example CDK stack that deploys the latest approved model to a SageMaker endpoint
- create Lambda function to query the model registry, with optional region support
- document how to set model package group name and region when deploying
- run Black formatting

## Testing
- `pytest -q`
- `black --check .`


------
https://chatgpt.com/codex/tasks/task_e_6881f8544084832fbc27419464de09da